### PR TITLE
fix: get hashtag by id route

### DIFF
--- a/src/services/apiHashtags.js
+++ b/src/services/apiHashtags.js
@@ -9,7 +9,7 @@ function getTrending(){
 }
 
 function getPostsByHashtag(hashtag,token){
-    const promise = axios.get(`${API_URL}/posts/${hashtag}`,ConfigToken(token));
+    const promise = axios.get(`${API_URL}/posts/hashtags/${hashtag}`,ConfigToken(token));
     return promise;
 }
 


### PR DESCRIPTION
- alterei a rota de pegar os posts através de uma hashtag por que estava muito generico, iria atrapalhar outras rotas.